### PR TITLE
Fix minor typo on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -49,7 +49,7 @@ description: |
         programmers.
       </p>
 
-      <p>Here's what happens at Code for San Francisco every week (see event page for each week for details):</p>
+      <p>Here's what happens at Code for San Francisco every week (see event page each week for details):</p>
 
       <h4>6:00pm – Socializing and food</h4>
 


### PR DESCRIPTION
Remove extra 'for'.